### PR TITLE
[FIX] Path traversal on "unicorn-list"

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -7,6 +7,8 @@ server.on('request', simpleResponse);
 
 function simpleResponse(request, response) {
   var responseContent;
+  
+  request.url = request.url.replace(/(\.\.)/g, '')
 
   if (request.url === '/') {
     responseContent = fs.readFile('./app/views/index.cats', endResponse);


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-unicorn-list/

### ⚙️ Description *

The `unicorn-list` server was vulnerable against a `path traversal` issue which made possible to anyone to access `private files` like `/etc/passwd`. The `..` in the path were evaluated and this made possible `reverse walk` through the files.

### 💻 Technical Description *

I simply avoided `request.url` could contain `..` in order to avoid `../` and similar techniques, which could lead to `path traversal` issues.

### 🐛 Proof of Concept (PoC) *

1. Create the 3 files here: https://github.com/JacksonGL/NPM-Vuln-PoC/tree/master/directory-traversal/unicorn-list
2. `node test.js`
3. `curl --path-as-is http://localhost:3000/../../../../../../../../../../../etc/passwd`

The `/etc/passwd` file is shown :cry:

### 🔥 Proof of Fix (PoF) *

Same steps with fixed version: no `/etc/passwd` files shown 😆 

### 👍 User Acceptance Testing (UAT)

All `ok` 👍 