### PR TITLE
Fixed Path traversal in unicorn-framework

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -7,8 +7,12 @@ server.on('request', simpleResponse);
 
 function simpleResponse(request, response) {
   var responseContent;
-
-  if (request.url === '/') {
+  if(request.url.includes('..')){
+    console.log("Error resolving context request: " + request.url);
+    response.writeHeader(500);
+    response.end();
+  }
+  else if (request.url === '/') {
     responseContent = fs.readFile('./app/views/index.cats', endResponse);
   }
   else if (request.url.match(/\.[^.]*$/)) {


### PR DESCRIPTION
### 📊 Metadata *
Fixed Path traversal
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-unicorn-list

### ⚙️ Description *
The ```unicorn-list``` server was vulnerable against a path traversal issue which made possible to anyone to access private files like ```/etc/passwd```. The ```..``` in the path were evaluated and this made possible reverse walk through the files.

### 💻 Technical Description *
I added a condition to block the url request that contains ```..```. 

### 🐛 Proof of Concept (PoC) *
1. ```mkdir test && cd test```
2. ```npm install unicorn-list```
2. Run the server ```npm start```
3. ```curl --path-as-is http://localhost:3000/../../../../../../../../../../../etc/passwd```
The ```/etc/passwd``` file is shown
![poc](https://user-images.githubusercontent.com/29670330/92617329-cc262400-f2dc-11ea-939d-df273a97ab26.png)

### 🔥 Proof of Fix (PoF) *
Path tarversal is not triggered. 
![pof](https://user-images.githubusercontent.com/29670330/92617402-df38f400-f2dc-11ea-90f3-e2269f95bf42.png)

### 👍 User Acceptance Testing (UAT)
App seems to be working fine. 
